### PR TITLE
chore(security): apply GitHub hardening policy files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
+# Global owners — all files require review from the repo owner
 * @icadariu

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  # Always update GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  # Uncomment and adjust for your ecosystem(s):
+
+  # - package-ecosystem: "npm"
+  #   directory: "/"
+  #   schedule:
+  #     interval: "weekly"
+  #   open-pull-requests-limit: 10
+
+  # - package-ecosystem: "pip"
+  #   directory: "/"
+  #   schedule:
+  #     interval: "weekly"
+  #   open-pull-requests-limit: 10
+
+  # - package-ecosystem: "gomod"
+  #   directory: "/"
+  #   schedule:
+  #     interval: "weekly"
+  #   open-pull-requests-limit: 10
+
+  # - package-ecosystem: "docker"
+  #   directory: "/"
+  #   schedule:
+  #     interval: "weekly"
+  #   open-pull-requests-limit: 10

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release receives security patches.
+
+| Version | Supported |
+|---------|-----------|
+| latest  | ✅        |
+| older   | ❌        |
+
+## Reporting a Vulnerability
+
+**Do not open a public issue for security vulnerabilities.**
+
+Report via [GitHub private vulnerability reporting](../../security/advisories/new)
+or email the repository owner directly.
+
+Include:
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested remediation (if any)
+
+## Response SLA
+
+| Severity | Initial response | Patch target |
+|----------|-----------------|--------------|
+| Critical | 24 hours        | 7 days       |
+| High     | 48 hours        | 14 days      |
+| Medium   | 5 business days | 30 days      |
+| Low      | 10 business days| 90 days      |
+
+## Disclosure Policy
+
+We follow coordinated disclosure. Please allow us time to patch before
+publishing details publicly.


### PR DESCRIPTION
## What

Automated hardening policy files generated by `github-harden.sh`.

### Files

| File | Purpose |
|------|---------|
| `SECURITY.md` | Vulnerability reporting process, SLA, and disclosure policy |
| `.github/CODEOWNERS` | Requires repo-owner review on all PRs |
| `.github/dependabot.yml` | Weekly Dependabot updates for GitHub Actions (add your ecosystems) |

## What was already applied directly

- ✅ Delete branch on merge
- ✅ Auto-merge enabled
- ✅ Always suggest updating pull request branches
- ✅ Web-commit signoff (DCO) required
- ✅ Private Vulnerability Reporting (PVR) — `SECURITY.md` advisory link works
- ✅ Immutable releases — published releases cannot be deleted or edited
- ✅ Dependabot vulnerability alerts
- ✅ Dependabot automated security fixes
- ✅ Secret scanning + push protection
- ✅ CodeQL default setup (best-effort; needs GHAS on private repos)
- ✅ Actions: `GITHUB_TOKEN` defaults to read-only; Actions cannot approve PRs
- ✅ Branch ruleset: PR + signed commits + no force-push + no default-branch deletion
- ✅ Tag ruleset: `v*` tags signed, non-deletable, non-force-pushable

## Next steps

1. Review and merge this PR
2. Edit `.github/dependabot.yml` to uncomment your package ecosystems
3. Ensure CI jobs are listed in the ruleset if you add required status checks