### PR TITLE
chore(security): apply GitHub hardening policy files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,5 @@
 version: 2
 updates:
-  # Always update GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## What

Automated hardening policy files generated by `github-harden.py`.

### Files

| File | Purpose |
|------|---------|
| `SECURITY.md` | Vulnerability reporting process, SLA, and disclosure policy |
| `.github/CODEOWNERS` | Requires repo-owner review on all PRs |
| `.github/dependabot.yml` | Weekly Dependabot updates for GitHub Actions |

## What was already applied directly

- ✅ Delete branch on merge
- ✅ Auto-merge enabled
- ✅ Always suggest updating pull request branches
- ✅ Web-commit signoff (DCO) required
- ✅ Private Vulnerability Reporting (PVR) — `SECURITY.md` advisory link works
- ✅ Immutable releases — published releases cannot be deleted or edited
- ✅ Dependabot vulnerability alerts
- ✅ Dependabot automated security fixes
- ✅ Secret scanning + push protection
- ✅ CodeQL default setup (best-effort; needs GHAS on private repos)
- ✅ Actions: `GITHUB_TOKEN` defaults to read-only; Actions cannot approve PRs
- ✅ Branch ruleset: PR + signed commits + no force-push + no deletion
- ✅ Tag ruleset: `v*` tags signed, non-deletable, non-force-pushable

## Next steps

1. Review and merge this PR
2. Edit `.github/dependabot.yml` to uncomment your package ecosystems
3. Ensure CI jobs are listed in the ruleset if you add required status checks