### PR TITLE
chore(security): apply GitHub hardening policy files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,29 +5,15 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
 
-  # Uncomment and adjust for your ecosystem(s):
-
-  # - package-ecosystem: "npm"
-  #   directory: "/"
-  #   schedule:
-  #     interval: "weekly"
-  #   open-pull-requests-limit: 10
-
-  # - package-ecosystem: "pip"
-  #   directory: "/"
-  #   schedule:
-  #     interval: "weekly"
-  #   open-pull-requests-limit: 10
-
-  # - package-ecosystem: "gomod"
-  #   directory: "/"
-  #   schedule:
-  #     interval: "weekly"
-  #   open-pull-requests-limit: 10
-
-  # - package-ecosystem: "docker"
-  #   directory: "/"
-  #   schedule:
-  #     interval: "weekly"
-  #   open-pull-requests-limit: 10
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,30 @@
+name: dependency-review
+
+on:
+  pull_request:
+
+permissions: {}
+
+concurrency:
+  group: dependency-review-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: review dependency changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        with:
+          persist-credentials: false
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48  # v4
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,40 @@
+name: gitleaks
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+  schedule:
+    - cron: "37 6 * * 1"
+  workflow_dispatch:
+
+# Deny-all at the workflow level; each job declares only what it needs.
+permissions: {}
+
+# Cancel superseded runs on the same ref so PR pushes don't pile up.
+concurrency:
+  group: gitleaks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: scan history for secrets
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        with:
+          fetch-depth: 0
+          # gitleaks only reads history; it never pushes back. Drop the token
+          # from `.git/config` so a compromised step can't reuse it.
+          persist-credentials: false
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITLEAKS_LICENSE is only required for organization accounts.
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}


### PR DESCRIPTION
## What

Automated hardening policy files generated by `github-harden.py`.

### Files

| File | Purpose |
|------|---------|
| `SECURITY.md` | Vulnerability reporting process, SLA, and disclosure policy |
| `.github/CODEOWNERS` | Requires repo-owner review on all PRs |
| `.github/dependabot.yml` | Weekly updates for: github-actions(/), gomod(/) |
| `.github/workflows/gitleaks.yml` | Secret-history scan in CI on push/PR + weekly schedule |
| `.github/workflows/dependency-review.yml` | Blocks PRs that introduce high-severity vulnerable dependencies |

## Hardening applied directly to the repository

- ✅ Delete branch on merge, auto-merge, squash-only, DCO, Wiki + Projects off
- ✅ Private Vulnerability Reporting (PVR)
- ✅ Immutable releases
- ✅ Dependabot vulnerability alerts
- ✅ Dependabot automated security fixes
- ✅ Secret scanning + push protection + non-provider patterns + validity checks
- ✅ Actions token read-only, cannot approve PRs
- ✅ Actions: `GITHUB_TOKEN` read-only; allowlist = github-owned + verified
- ✅ Branch ruleset: PR + signed commits + linear history + no force-push + no deletion
- ✅ Tag ruleset: `v*` tags signed, non-deletable, non-force-pushable

## Next steps

1. Review and merge this PR
2. Review `.github/dependabot.yml` ecosystems (auto-detected — adjust if needed)
3. Add required status checks to the branch ruleset once CI exists (start with `gitleaks / scan history for secrets`)
4. To also enable the repo-level `sha_pinning_required` Actions toggle, re-run with `--strict`. (Workflow files themselves are SHA-pinned by default.)