### PR TITLE
chore: add Makefile and document update flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+CMD_PKG ?= .
+BIN     ?= tmux-ktx
+GOFLAGS ?=
+LDFLAGS ?= -s -w
+
+.PHONY: build install test fmt vet clean
+
+build:
+	go build $(GOFLAGS) -ldflags '$(LDFLAGS)' -o $(BIN) $(CMD_PKG)
+
+install:
+	go install $(GOFLAGS) -ldflags '$(LDFLAGS)' $(CMD_PKG)
+
+test:
+	go test ./...
+
+fmt:
+	gofmt -s -w .
+
+vet:
+	go vet ./...
+
+clean:
+	rm -f $(BIN)

--- a/README.md
+++ b/README.md
@@ -19,11 +19,38 @@
 * Go 1.23+
 * tmux
 
-## Build
+## Build & Install
+
+Build a local binary in the repo root:
 
 ```bash
-go build -o tmux-ktx .
+make build
 ```
+
+Install into your Go bin directory (`$GOBIN`, or `$(go env GOPATH)/bin` if `GOBIN` is unset):
+
+```bash
+make install
+```
+
+Make sure that directory is on your `$PATH`. Override defaults if needed:
+
+```bash
+make install LDFLAGS='-s -w' GOFLAGS='-trimpath'
+```
+
+Other targets: `make test`, `make fmt`, `make vet`, `make clean`.
+
+## Updating
+
+Dependabot opens PRs that bump Go modules and GitHub Actions in this repo. Once those PRs merge into `main`, refresh your local binary:
+
+```bash
+git pull --ff-only
+make install
+```
+
+This rebuilds `tmux-ktx` against the latest merged module versions and replaces the binary in `$(go env GOPATH)/bin`.
 
 ## How it works
 
@@ -88,7 +115,7 @@ set -g status-right "#(myPath/tmux-ktx -ctx-color green -ns-color red #{@ktx_kub
 set -g status-interval 5
 ```
 
-> **Note:** Use full path since tmux does not expand `~` in shell command substitutions.
+> **Note:** Use the full path since tmux does not expand `~` or `$GOPATH` in shell command substitutions. If you installed via `make install`, the binary lives at `$(go env GOPATH)/bin/tmux-ktx` — substitute that absolute path for `myPath/tmux-ktx` above.
 
 The plugin reads `KUBECONFIG` from the pane option set by the shell hook. If the option is
 empty, it falls back to `~/.kube/config`. When no context is configured, nothing is displayed


### PR DESCRIPTION
## Why

The repo had no build automation — the README told users to run `go build -o tmux-ktx .` by hand. Dependabot is opening PRs against this repo on a regular cadence (recent: `actions/checkout`, `actions/dependency-review-action`), so module/action bumps land in `main` often, but users who installed the binary locally had no documented way to "make sure I'm on the latest version" once those PRs merge.

## What

- **New `Makefile`** with `build`, `install`, `test`, `fmt`, `vet`, `clean` targets. Variables `CMD_PKG`, `BIN`, `GOFLAGS`, `LDFLAGS` are overridable; default `LDFLAGS=-s -w` (strip).
  - `install` uses `go install $(GOFLAGS) -ldflags '$(LDFLAGS)' $(CMD_PKG)` so the binary lands in `$GOBIN` / `$(go env GOPATH)/bin`.
- **`README.md`**:
  - Replaced `## Build` with `## Build & Install` covering `make build` and `make install`, plus the `$PATH` requirement and an override example.
  - Added `## Updating` documenting the post-Dependabot refresh: `git pull --ff-only && make install`.
  - Updated the existing Usage note so the `myPath/tmux-ktx` placeholder points at `$(go env GOPATH)/bin/tmux-ktx` for installs via `make install`.

## How

`go install` was chosen over a hand-rolled `cp` to `~/bin/` so the install target follows standard Go tooling conventions (respects `GOBIN`, no `sudo`, no path hardcoded in the Makefile). No `main.version` variable was added — `LDFLAGS` defaults to `-s -w` for stripping only, leaving version-stamping as a future, optional change rather than scope creep here.

### Test plan

- [x] `make build` produces a stripped ELF binary; `./tmux-ktx` runs and exits 0.
- [x] `make install` writes `tmux-ktx` to `$(go env GOPATH)/bin/`.
- [x] `make test` — `internal/kube` tests pass.
- [x] `make vet` — clean.
- [x] `make fmt` — no diff.
- [x] `make clean` — removes `./tmux-ktx`.
- [ ] Reviewer: skim README rendering on GitHub to confirm the new `Build & Install` and `Updating` sections look right.
