### PR TITLE
refactor(cli): drop `version` subcommand, standardize `--version`

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -50,24 +50,16 @@ func runBinary(t *testing.T, args ...string) (string, string, int) {
 	return stdout.String(), stderr.String(), exit
 }
 
-func TestVersionSubcommandPrintsKdiagFormat(t *testing.T) {
-	stdout, stderr, exit := runBinary(t, "version")
+func TestVersionFlagPrintsCanonicalFormat(t *testing.T) {
+	stdout, stderr, exit := runBinary(t, "--version")
 	if exit != 0 {
 		t.Fatalf("exit %d, stderr=%q", exit, stderr)
 	}
 	line := strings.TrimRight(stdout, "\n")
-	// Expected shape: "tmux-ktx <git-describe> (built <YY-MM-DD_HH:MM>, commit <sha>)"
-	re := regexp.MustCompile(`^tmux-ktx \S+ \(built \S+, commit \S+\)$`)
+	// Expected shape: "<version> (built <YY-MM-DD_HH:MM>, commit <sha>)" (no app name)
+	re := regexp.MustCompile(`^\S+ \(built \S+, commit \S+\)$`)
 	if !re.MatchString(line) {
-		t.Errorf("version line %q does not match kdiag format %q", line, re)
-	}
-}
-
-func TestVersionLongFlagMatchesSubcommand(t *testing.T) {
-	subOut, _, _ := runBinary(t, "version")
-	flagOut, _, _ := runBinary(t, "--version")
-	if subOut != flagOut {
-		t.Errorf("`version` and `--version` produced different output:\n  sub:  %q\n  flag: %q", subOut, flagOut)
+		t.Errorf("version line %q does not match canonical format %q", line, re)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -14,34 +14,26 @@ var (
 	buildTime = "unknown"
 )
 
-func formatVersion(name, version, buildTime, commit string) string {
-	return fmt.Sprintf("%s %s (built %s, commit %s)", name, version, buildTime, commit)
-}
-
-func printVersion() {
-	fmt.Println(formatVersion("tmux-ktx", version, buildTime, commit))
-}
-
-func formatTmuxOutput(ctx, ns, ctxColor, nsColor string) string {
-	return fmt.Sprintf("#[fg=blue]⎈ #[fg=%s]%s#[fg=colour250]:#[fg=%s]%s", ctxColor, ctx, nsColor, ns)
-}
-
-func isVersionRequest(args []string) bool {
-	if len(args) < 2 {
-		return false
-	}
-	for _, a := range args[1:] {
-		switch a {
-		case "version", "-version", "--version":
+// HandleVersionFlag prints the version line and returns true if --version
+// (or -version) was passed. Call at the top of main():
+//
+//	if HandleVersionFlag() { return }
+func HandleVersionFlag() bool {
+	for _, a := range os.Args[1:] {
+		if a == "--version" || a == "-version" {
+			fmt.Printf("%s (built %s, commit %s)\n", version, buildTime, commit)
 			return true
 		}
 	}
 	return false
 }
 
+func formatTmuxOutput(ctx, ns, ctxColor, nsColor string) string {
+	return fmt.Sprintf("#[fg=blue]⎈ #[fg=%s]%s#[fg=colour250]:#[fg=%s]%s", ctxColor, ctx, nsColor, ns)
+}
+
 func main() {
-	if isVersionRequest(os.Args) {
-		printVersion()
+	if HandleVersionFlag() {
 		return
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -2,41 +2,10 @@ package main
 
 import "testing"
 
-func TestFormatVersion(t *testing.T) {
-	got := formatVersion("tmux-ktx", "v0.0.1-1-g98d2612", "22-05-26_20:49", "98d2612")
-	want := "tmux-ktx v0.0.1-1-g98d2612 (built 22-05-26_20:49, commit 98d2612)"
-	if got != want {
-		t.Errorf("formatVersion:\n  got  %q\n  want %q", got, want)
-	}
-}
-
 func TestFormatTmuxOutput(t *testing.T) {
 	got := formatTmuxOutput("kind-kind", "my-namespace", "green", "red")
 	want := "#[fg=blue]⎈ #[fg=green]kind-kind#[fg=colour250]:#[fg=red]my-namespace"
 	if got != want {
 		t.Errorf("formatTmuxOutput:\n  got  %q\n  want %q", got, want)
-	}
-}
-
-func TestIsVersionRequest(t *testing.T) {
-	tests := []struct {
-		name string
-		args []string
-		want bool
-	}{
-		{"version subcommand", []string{"tmux-ktx", "version"}, true},
-		{"--version long flag", []string{"tmux-ktx", "--version"}, true},
-		{"-version short flag (Go flag pkg style)", []string{"tmux-ktx", "-version"}, true},
-		{"no args", []string{"tmux-ktx"}, false},
-		{"unrelated flag", []string{"tmux-ktx", "-ctx-color", "green"}, false},
-		{"kubeconfig positional", []string{"tmux-ktx", "/home/user/.kube/config"}, false},
-		{"version-like flag among others", []string{"tmux-ktx", "-ctx-color", "green", "--version"}, true},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := isVersionRequest(tc.args); got != tc.want {
-				t.Errorf("isVersionRequest(%v) = %v, want %v", tc.args, got, tc.want)
-			}
-		})
 	}
 }


### PR DESCRIPTION
## Why
Adopt the canonical Go `--version` standard from the user's dotfiles (icadariu/dotfiles#7). The standard requires `app --version` only (no `version` subcommand) and an output line in the format `<version> (built YY-MM-DD_HH:MM, commit <sha>)` — no app-name prefix.

## What
- Removed `formatVersion()`, `printVersion()`, and `isVersionRequest()` helpers
- Added `HandleVersionFlag()` to intercept `--version` before flag parsing
- Updated version output format: removed "tmux-ktx " prefix
- Removed `version` subcommand tests; replaced with `TestVersionFlagPrintsCanonicalFormat()`

## How
Call `HandleVersionFlag()` at the start of `main()` to short-circuit before flag parsing. This avoids checking flags multiple times.

### Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [ ] Run `./tmux-ktx --version` after `make install` and confirm output matches `<version> (built YY-MM-DD_HH:MM, commit <sha>)`.
