### PR TITLE
ci(test): run go vet and test on push and PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions: {}
+
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: vet and test
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test ./...


### PR DESCRIPTION
## Why
The repo has a solid test suite but no CI ran it — the only workflow was `dependency-review.yml`. Regressions could land on `main` unnoticed.

## What
- Add `.github/workflows/test.yml` running `go vet ./...` and `go test ./...` on pushes to `main` and on pull requests.

## How
Matches the existing hardened workflow conventions: SHA-pinned actions (`actions/checkout` v6.0.2, `actions/setup-go` v6.4.0), top-level `permissions: {}` with `contents: read` on the job, concurrency cancellation, a 5-minute timeout, and `persist-credentials: false`. Uses `go-version-file: go.mod` so the CI toolchain tracks `go.mod` rather than a hardcoded version.

### Test plan
- [x] `go vet ./...` clean locally
- [x] `go test ./...` passes locally (both packages)
- [x] workflow YAML parses
- [ ] confirm the `test` workflow goes green on the PR in GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
